### PR TITLE
This is a good approach for adding dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,27 @@
+from setuptools import setup, find_packages
+
+setup(name='dined',
+      version='0.1',
+      description='The name of your package',
+      url='',
+      author='',
+      author_email='',
+      license='',
+      packages=find_packages(),
+      install_requires=[
+            # Put here what is required for your package to run
+      ],
+      extras_require={
+      # Put here any development dependencies for your package
+        'dev': [
+            'pytest',
+            'pytest-pep8',
+            'pytest-cov',
+            'jupyter',
+            'notebook',
+            'pylint'
+        ]
+      },
+      zip_safe=False
+)
+


### PR DESCRIPTION
We separate development dependencies from package dependencies. This is important to setup the python environment.
Once this is ready you can simply do:
`pip install -e .[dev]`
This command will not only install your package dependencies into the environment but also the development dependencies.

@fvanoorschot this is just a placeholder, we need to add the dependencies in the `setup.py` still.